### PR TITLE
Remove engine version to be "version-agnostic".

### DIFF
--- a/userreg-react-beanstalk/package.json
+++ b/userreg-react-beanstalk/package.json
@@ -16,9 +16,6 @@
     "serve": "11.3.2",
     "uuid": "^8.3.0"
   },
-  "engines": {
-    "node": "12.16.1"
-  },
   "scripts": {
     "start": "react-scripts build && serve -s build",
     "start-local": "react-scripts start",


### PR DESCRIPTION
*Issue #, if available:* #1

*Description of changes:* Remove the unnecessary engine version, as "api-node" application. In this way, it's possible to deploy the webapp using NodeJS 14 runtime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
